### PR TITLE
Entitäten-Stubs erzeugt 

### DIFF
--- a/backend/src/main/java/entities/Achievement.java
+++ b/backend/src/main/java/entities/Achievement.java
@@ -1,0 +1,6 @@
+package entities;
+import javax.persistence.Entity;
+
+@Entity
+public class Achievement extends EntityGeneratedKey{
+}

--- a/backend/src/main/java/entities/BundesligaTable.java
+++ b/backend/src/main/java/entities/BundesligaTable.java
@@ -1,0 +1,6 @@
+package entities;
+import javax.persistence.Entity;
+
+@Entity
+public class BundesligaTable {
+}

--- a/backend/src/main/java/entities/EntityExternalKey.java
+++ b/backend/src/main/java/entities/EntityExternalKey.java
@@ -1,0 +1,21 @@
+package entities;
+
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+import java.io.Serializable;
+
+@MappedSuperclass
+public class EntityExternalKey implements Serializable {
+
+    @Id
+    private int id;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+}

--- a/backend/src/main/java/entities/EntityGeneratedKey.java
+++ b/backend/src/main/java/entities/EntityGeneratedKey.java
@@ -1,0 +1,24 @@
+package entities;
+
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+import java.io.Serializable;
+
+@MappedSuperclass
+public class EntityGeneratedKey implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private int id;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+}

--- a/backend/src/main/java/entities/Group.java
+++ b/backend/src/main/java/entities/Group.java
@@ -1,0 +1,6 @@
+package entities;
+import javax.persistence.Entity;
+
+@Entity
+public class Group extends EntityGeneratedKey {
+}

--- a/backend/src/main/java/entities/League.java
+++ b/backend/src/main/java/entities/League.java
@@ -1,0 +1,6 @@
+package entities;
+import javax.persistence.Entity;
+
+@Entity
+public class League extends EntityExternalKey {
+}

--- a/backend/src/main/java/entities/Match.java
+++ b/backend/src/main/java/entities/Match.java
@@ -1,0 +1,7 @@
+package entities;
+import javax.persistence.Entity;
+
+@Entity
+public class Match extends EntityExternalKey{
+
+}

--- a/backend/src/main/java/entities/Matchday.java
+++ b/backend/src/main/java/entities/Matchday.java
@@ -1,0 +1,6 @@
+package entities;
+import javax.persistence.Entity;
+
+@Entity
+public class Matchday extends EntityExternalKey{
+}

--- a/backend/src/main/java/entities/NewsfeedMessage.java
+++ b/backend/src/main/java/entities/NewsfeedMessage.java
@@ -1,0 +1,6 @@
+package entities;
+import javax.persistence.Entity;
+
+@Entity
+public class NewsfeedMessage extends EntityGeneratedKey{
+}

--- a/backend/src/main/java/entities/Team.java
+++ b/backend/src/main/java/entities/Team.java
@@ -1,0 +1,7 @@
+package entities;
+
+import javax.persistence.Entity;
+
+@Entity
+public class Team extends EntityExternalKey {
+}

--- a/backend/src/main/java/entities/User.java
+++ b/backend/src/main/java/entities/User.java
@@ -1,0 +1,5 @@
+package entities;
+
+public class User extends EntityGeneratedKey {
+
+}


### PR DESCRIPTION
zwei Varianten bei den IDs:

- extern durch API vorgegeben, z.B. Match
- intern vergeben (auto-increment), z.B. User